### PR TITLE
Initial commit for the KartaQuest plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.kartaquest</groupId>
+    <artifactId>KartaQuest</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>KartaQuest</name>
+
+    <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/kartaquest/KartaQuest.java
+++ b/src/main/java/com/kartaquest/KartaQuest.java
@@ -1,0 +1,99 @@
+package com.kartaquest;
+
+import com.kartaquest.commands.ReputationsCommand;
+import com.kartaquest.data.Contract;
+import com.kartaquest.expansion.KartaQuestExpansion;
+import com.kartaquest.listeners.GUIListener;
+import com.kartaquest.managers.ConfigManager;
+import com.kartaquest.managers.ContractManager;
+import com.kartaquest.managers.EconomyManager;
+import com.kartaquest.managers.ReputationManager;
+import com.kartaquest.utils.DataManager;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public final class KartaQuest extends JavaPlugin {
+
+    private ConfigManager configManager;
+    private EconomyManager economyManager;
+    private ContractManager contractManager;
+    private ReputationManager reputationManager;
+    private DataManager dataManager;
+
+    @Override
+    public void onEnable() {
+        // Initialize Managers
+        configManager = new ConfigManager(this);
+        dataManager = new DataManager(this);
+        economyManager = new EconomyManager(this);
+        contractManager = new ContractManager(this);
+        reputationManager = new ReputationManager(this);
+
+        // Register commands
+        getCommand("kartaquest").setExecutor(new com.kartaquest.commands.KartaQuestCommand(this));
+        getCommand("kartaquest").setTabCompleter(new com.kartaquest.commands.KartaQuestCommand(this));
+        getCommand("reputations").setExecutor(new ReputationsCommand(this));
+
+        // Register listeners
+        getServer().getPluginManager().registerEvents(new GUIListener(this), this);
+
+        // Register PlaceholderAPI expansion
+        if(getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new KartaQuestExpansion(this).register();
+            getLogger().info("Successfully registered PlaceholderAPI expansion.");
+        }
+
+        startExpirationTask();
+
+        getLogger().info("KartaQuest has been enabled!");
+    }
+
+    private void startExpirationTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                long now = System.currentTimeMillis();
+                getContractManager().getActiveContracts().values().stream()
+                        .filter(c -> c.status() == Contract.ContractStatus.AVAILABLE || c.status() == Contract.ContractStatus.IN_PROGRESS)
+                        .filter(c -> c.timeLimit() > 0 && c.timeLimit() < now)
+                        .forEach(c -> {
+                            getLogger().info("Contract " + c.contractId() + " has expired.");
+                            getContractManager().expireContract(c.contractId());
+                        });
+            }
+        }.runTaskTimer(this, 0L, 20L * 60 * 5); // Check every 5 minutes
+    }
+
+    @Override
+    public void onDisable() {
+        // Save data on disable
+        if (contractManager != null) {
+            contractManager.saveContracts();
+        }
+        if (reputationManager != null) {
+            reputationManager.saveReputations();
+        }
+        getLogger().info("KartaQuest has been disabled!");
+    }
+
+    // Getters for managers
+    public ConfigManager getConfigManager() {
+        return configManager;
+    }
+
+    public EconomyManager getEconomyManager() {
+        return economyManager;
+    }
+
+    public ContractManager getContractManager() {
+        return contractManager;
+    }
+
+    public ReputationManager getReputationManager() {
+        return reputationManager;
+    }
+
+    public DataManager getDataManager() {
+        return dataManager;
+    }
+}

--- a/src/main/java/com/kartaquest/commands/KartaQuestCommand.java
+++ b/src/main/java/com/kartaquest/commands/KartaQuestCommand.java
@@ -1,0 +1,284 @@
+package com.kartaquest.commands;
+
+import com.kartaquest.KartaQuest;
+import com.kartaquest.data.Contract;
+import com.kartaquest.gui.ContractGUI;
+import com.kartaquest.utils.TimeParser;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class KartaQuestCommand implements CommandExecutor, TabCompleter {
+    // ... (existing code up to handleCreateCommand)
+    private final KartaQuest plugin;
+
+    public KartaQuestCommand(KartaQuest plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getConfigManager().getMessage("player-only-command"));
+            return true;
+        }
+
+        if (args.length == 0) {
+            new ContractGUI(plugin, player, 0).open();
+            return true;
+        }
+
+        String subCommand = args[0].toLowerCase();
+        switch (subCommand) {
+            case "create":
+                handleCreateCommand(player, args);
+                break;
+            case "status":
+                handleStatusCommand(player);
+                break;
+            case "complete":
+                handleCompleteCommand(player);
+                break;
+            case "cancel":
+                handleCancelCommand(player);
+                break;
+            case "claim":
+                handleClaimCommand(player);
+                break;
+            case "admin":
+                handleAdminCommand(player, args);
+                break;
+            default:
+                player.sendMessage(plugin.getConfigManager().getMessage("unknown-command"));
+                break;
+        }
+
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length == 1) {
+            List<String> subCommands = List.of("create", "status", "complete", "cancel", "claim");
+            List<String> completions = new ArrayList<>();
+            for (String s : subCommands) {
+                if (s.startsWith(args[0].toLowerCase())) {
+                    completions.add(s);
+                }
+            }
+            if (sender.hasPermission("kartaquest.admin")) {
+                if ("admin".startsWith(args[0].toLowerCase())) {
+                    completions.add("admin");
+                }
+            }
+            return completions;
+        }
+        return new ArrayList<>();
+    }
+
+    private void handleCreateCommand(Player player, String[] args) {
+        if (args.length < 4 || args.length > 5) {
+            player.sendMessage(plugin.getConfigManager().getMessage("creation-usage")); // Should update usage message
+            return;
+        }
+
+        // Max contract check
+        int maxContracts = plugin.getConfigManager().getMaxContractsPerPlayer();
+        long currentContracts = plugin.getContractManager().getActiveContracts().values().stream()
+                .filter(c -> c.creatorUuid().equals(player.getUniqueId())).count();
+        if (currentContracts >= maxContracts) {
+            player.sendMessage(plugin.getConfigManager().getMessage("max-contracts-reached", Placeholder.unparsed("max", String.valueOf(maxContracts))));
+            return;
+        }
+
+        Material material;
+        try {
+            material = Material.valueOf(args[1].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(plugin.getConfigManager().getMessage("invalid-item", Placeholder.unparsed("item", args[1])));
+            return;
+        }
+
+        int amount;
+        try {
+            amount = Integer.parseInt(args[2]);
+            if (amount <= 0) {
+                player.sendMessage(plugin.getConfigManager().getMessage("invalid-amount"));
+                return;
+            }
+        } catch (NumberFormatException e) {
+            player.sendMessage(plugin.getConfigManager().getMessage("invalid-amount"));
+            return;
+        }
+
+        double price;
+        try {
+            price = Double.parseDouble(args[3]);
+            if (price <= 0) {
+                player.sendMessage(plugin.getConfigManager().getMessage("invalid-price"));
+                return;
+            }
+        } catch (NumberFormatException e) {
+            player.sendMessage(plugin.getConfigManager().getMessage("invalid-price"));
+            return;
+        }
+
+        long timeLimit = 0;
+        if (args.length == 5) {
+            timeLimit = TimeParser.parseTime(args[4]);
+            if (timeLimit == 0) {
+                // TimeParser returns 0 if format is invalid
+                player.sendMessage("Invalid time format. Use d, h, m, s. Example: 7d, 12h, 30m");
+                return;
+            }
+        }
+
+        double tax = price * (plugin.getConfigManager().getContractCreationTaxPercent() / 100.0);
+        double totalCost = price + tax;
+
+        if (!plugin.getEconomyManager().has(player, totalCost)) {
+            player.sendMessage(plugin.getConfigManager().getMessage("insufficient-funds",
+                    Placeholder.unparsed("price", String.format("%,.2f", price)),
+                    Placeholder.unparsed("tax", String.format("%,.2f", tax))
+            ));
+            return;
+        }
+
+        EconomyResponse response = plugin.getEconomyManager().withdrawPlayer(player, totalCost);
+        if (!response.transactionSuccess()) {
+            player.sendMessage("An unexpected error occurred during the transaction.");
+            return;
+        }
+
+        plugin.getContractManager().createContract(player.getUniqueId(), player.getName(), material, amount, price, timeLimit);
+        player.sendMessage(plugin.getConfigManager().getMessage("contract-created",
+                Placeholder.unparsed("amount", String.valueOf(amount)),
+                Placeholder.unparsed("item", material.name()),
+                Placeholder.unparsed("price", String.format("%,.2f", price))
+        ));
+    }
+
+    // ... other handle methods
+    private void handleStatusCommand(Player player) {
+        Contract contract = plugin.getContractManager().getContractByAssignee(player.getUniqueId());
+        if (contract == null) {
+            player.sendMessage(plugin.getConfigManager().getMessage("no-active-contract"));
+            return;
+        }
+
+        player.sendMessage(plugin.getConfigManager().getMessage("contract-status",
+                Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
+                Placeholder.unparsed("item", contract.itemType().name()),
+                Placeholder.unparsed("reward", String.format("%,.2f", contract.reward())),
+                Placeholder.unparsed("creator", contract.creatorName())
+        ));
+    }
+    private void handleCompleteCommand(Player player) {
+        Contract contract = plugin.getContractManager().getContractByAssignee(player.getUniqueId());
+        if (contract == null) {
+            player.sendMessage(plugin.getConfigManager().getMessage("no-active-contract"));
+            return;
+        }
+
+        if (!player.getInventory().containsAtLeast(new ItemStack(contract.itemType()), contract.itemAmount())) {
+            player.sendMessage(plugin.getConfigManager().getMessage("not-enough-items",
+                    Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
+                    Placeholder.unparsed("item", contract.itemType().name())
+            ));
+            return;
+        }
+
+        player.getInventory().removeItem(new ItemStack(contract.itemType(), contract.itemAmount()));
+        plugin.getEconomyManager().depositPlayer(player, contract.reward());
+        plugin.getReputationManager().addReputation(player.getUniqueId(), 1);
+        plugin.getReputationManager().incrementCompletedContracts(player.getUniqueId());
+        plugin.getContractManager().completeContract(contract.contractId());
+
+        player.sendMessage(plugin.getConfigManager().getMessage("contract-completed",
+                Placeholder.unparsed("reward", String.format("%,.2f", contract.reward()))
+        ));
+    }
+
+    private void handleCancelCommand(Player player) {
+        Contract contract = plugin.getContractManager().getContractByAssignee(player.getUniqueId());
+        if (contract == null) {
+            player.sendMessage(plugin.getConfigManager().getMessage("no-active-contract"));
+            return;
+        }
+
+        plugin.getContractManager().cancelContract(contract.contractId());
+        plugin.getReputationManager().removeReputation(player.getUniqueId(), 1);
+
+        player.sendMessage(plugin.getConfigManager().getMessage("contract-cancelled"));
+    }
+
+    private void handleClaimCommand(Player player) {
+        List<Contract> claimable = plugin.getContractManager().getClaimableContracts(player.getUniqueId());
+        if (claimable.isEmpty()) {
+            player.sendMessage(plugin.getConfigManager().getMessage("no-items-to-claim"));
+            return;
+        }
+
+        for (Contract contract : claimable) {
+            player.getInventory().addItem(new ItemStack(contract.itemType(), contract.itemAmount()));
+            plugin.getContractManager().removeContract(contract.contractId());
+            player.sendMessage(plugin.getConfigManager().getMessage("claimed-items",
+                    Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
+                    Placeholder.unparsed("item", contract.itemType().name())
+            ));
+        }
+    }
+
+    private void handleAdminCommand(Player player, String[] args) {
+        if (!player.hasPermission("kartaquest.admin")) {
+            player.sendMessage(plugin.getConfigManager().getMessage("unknown-command")); // Hide admin command
+            return;
+        }
+
+        if (args.length < 2) {
+            player.sendMessage(plugin.getConfigManager().getMessage("admin-help"));
+            return;
+        }
+
+        String adminSubCommand = args[1].toLowerCase();
+        switch (adminSubCommand) {
+            case "reload":
+                plugin.getConfigManager().reloadConfig();
+                player.sendMessage(plugin.getConfigManager().getMessage("config-reloaded"));
+                break;
+            case "delete":
+                if (args.length < 3) {
+                    player.sendMessage("Usage: /kq admin delete <contract-id>");
+                    return;
+                }
+                try {
+                    UUID contractId = UUID.fromString(args[2]);
+                    if (plugin.getContractManager().getContract(contractId) == null) {
+                        player.sendMessage(plugin.getConfigManager().getMessage("contract-not-found", Placeholder.unparsed("id", args[2])));
+                    } else {
+                        plugin.getContractManager().removeContract(contractId);
+                        player.sendMessage(plugin.getConfigManager().getMessage("contract-deleted", Placeholder.unparsed("id", args[2])));
+                    }
+                } catch (IllegalArgumentException e) {
+                    player.sendMessage(plugin.getConfigManager().getMessage("contract-not-found", Placeholder.unparsed("id", args[2])));
+                }
+                break;
+            default:
+                player.sendMessage(plugin.getConfigManager().getMessage("admin-help"));
+                break;
+        }
+    }
+}

--- a/src/main/java/com/kartaquest/commands/ReputationsCommand.java
+++ b/src/main/java/com/kartaquest/commands/ReputationsCommand.java
@@ -1,0 +1,52 @@
+package com.kartaquest.commands;
+
+import com.kartaquest.KartaQuest;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class ReputationsCommand implements CommandExecutor {
+
+    private final KartaQuest plugin;
+
+    public ReputationsCommand(KartaQuest plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length == 0) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(plugin.getConfigManager().getMessage("player-only-command"));
+                return true;
+            }
+            int reputation = plugin.getReputationManager().getReputation(player.getUniqueId());
+            player.sendMessage(plugin.getConfigManager().getMessage("reputation-check-self",
+                    Placeholder.unparsed("reputation", String.valueOf(reputation))
+            ));
+            return true;
+        }
+
+        if (args.length == 1) {
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+            if (!target.hasPlayedBefore() && !target.isOnline()) {
+                sender.sendMessage(plugin.getConfigManager().getMessage("player-not-found"));
+                return true;
+            }
+            int reputation = plugin.getReputationManager().getReputation(target.getUniqueId());
+            sender.sendMessage(plugin.getConfigManager().getMessage("reputation-check-other",
+                    Placeholder.unparsed("player", target.getName()),
+                    Placeholder.unparsed("reputation", String.valueOf(reputation))
+            ));
+            return true;
+        }
+
+        sender.sendMessage("Usage: /reputation [player]"); // This can be a configurable message too
+        return true;
+    }
+}

--- a/src/main/java/com/kartaquest/data/Contract.java
+++ b/src/main/java/com/kartaquest/data/Contract.java
@@ -1,0 +1,31 @@
+package com.kartaquest.data;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+public record Contract(
+    UUID contractId,
+    UUID creatorUuid,
+    String creatorName,
+    Material itemType,
+    int itemAmount,
+    double reward,
+    ContractStatus status,
+    UUID assigneeUuid,
+    long creationTimestamp,
+    long timeLimit // 0 for no limit
+) {
+
+    public enum ContractStatus {
+        AVAILABLE,
+        IN_PROGRESS,
+        COMPLETED_UNCLAIMED,
+        EXPIRED
+    }
+
+    public ItemStack getDisplayItem() {
+        return new ItemStack(itemType, 1);
+    }
+}

--- a/src/main/java/com/kartaquest/expansion/KartaQuestExpansion.java
+++ b/src/main/java/com/kartaquest/expansion/KartaQuestExpansion.java
@@ -1,0 +1,73 @@
+package com.kartaquest.expansion;
+
+import com.kartaquest.KartaQuest;
+import com.kartaquest.data.Contract;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+public class KartaQuestExpansion extends PlaceholderExpansion {
+
+    private final KartaQuest plugin;
+
+    public KartaQuestExpansion(KartaQuest plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "kartaquest";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "MinekartaStudio";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String params) {
+        if (player == null) {
+            return "";
+        }
+
+        switch (params) {
+            case "reputation":
+                return String.valueOf(plugin.getReputationManager().getReputation(player.getUniqueId()));
+
+            case "contracts_completed":
+                return String.valueOf(plugin.getReputationManager().getCompletedContracts(player.getUniqueId()));
+
+            case "contracts_created":
+                long createdCount = plugin.getContractManager().getActiveContracts().values().stream()
+                        .filter(c -> c.creatorUuid().equals(player.getUniqueId())).count();
+                return String.valueOf(createdCount);
+
+            case "active_contract_name":
+                Contract activeContract = plugin.getContractManager().getContractByAssignee(player.getUniqueId());
+                if (activeContract != null) {
+                    return "Collect " + activeContract.itemAmount() + " " + activeContract.itemType().name();
+                }
+                return "None";
+
+            case "active_contract_reward":
+                Contract activeContractReward = plugin.getContractManager().getContractByAssignee(player.getUniqueId());
+                if (activeContractReward != null) {
+                    return String.format("%,.2f", activeContractReward.reward());
+                }
+                return "0.00";
+
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/com/kartaquest/gui/ContractGUI.java
+++ b/src/main/java/com/kartaquest/gui/ContractGUI.java
@@ -1,0 +1,107 @@
+package com.kartaquest.gui;
+
+import com.kartaquest.KartaQuest;
+import com.kartaquest.data.Contract;
+import com.kartaquest.utils.TimeParser;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContractGUI {
+
+    private final KartaQuest plugin;
+    private final Player player;
+    private int page;
+    private static final int CONTRACTS_PER_PAGE = 45; // 9x5
+
+    public ContractGUI(KartaQuest plugin, Player player, int page) {
+        this.plugin = plugin;
+        this.player = player;
+        this.page = page;
+    }
+
+    public void open() {
+        List<Contract> availableContracts = plugin.getContractManager().getAvailableContracts();
+        ContractGUIHolder holder = new ContractGUIHolder(page);
+
+        int totalPages = Math.max(1, (int) Math.ceil((double) availableContracts.size() / CONTRACTS_PER_PAGE));
+        // We don't add the prefix to the GUI title, so call deserialize directly.
+        Component title = MiniMessage.miniMessage().deserialize(plugin.getConfig().getString("messages.gui-title"),
+                Placeholder.unparsed("page", String.valueOf(page + 1)),
+                Placeholder.unparsed("total_pages", String.valueOf(totalPages)));
+
+        Inventory gui = Bukkit.createInventory(holder, 54, title);
+
+        int startIndex = page * CONTRACTS_PER_PAGE;
+        int endIndex = Math.min(startIndex + CONTRACTS_PER_PAGE, availableContracts.size());
+
+        for (int i = startIndex; i < endIndex; i++) {
+            int slot = i % CONTRACTS_PER_PAGE;
+            Contract contract = availableContracts.get(i);
+            gui.setItem(slot, createContractItem(contract));
+            holder.setContractAtSlot(slot, contract.contractId());
+        }
+
+        // Add navigation items
+        if (page > 0) {
+            ItemStack previous = new ItemStack(Material.ARROW);
+            ItemMeta prevMeta = previous.getItemMeta();
+            prevMeta.displayName(MiniMessage.miniMessage().deserialize("<gray>Previous Page"));
+            previous.setItemMeta(prevMeta);
+            gui.setItem(45, previous); // Bottom-left
+        }
+
+        if (endIndex < availableContracts.size()) {
+            ItemStack next = new ItemStack(Material.ARROW);
+            ItemMeta nextMeta = next.getItemMeta();
+            nextMeta.displayName(MiniMessage.miniMessage().deserialize("<gray>Next Page"));
+            next.setItemMeta(nextMeta);
+            gui.setItem(53, next); // Bottom-right
+        }
+
+        player.openInventory(gui);
+    }
+
+    private ItemStack createContractItem(Contract contract) {
+        ItemStack item = new ItemStack(contract.itemType());
+        ItemMeta meta = item.getItemMeta();
+        MiniMessage mm = MiniMessage.miniMessage();
+
+        // Title
+        String titleFormat = plugin.getConfig().getString("messages.gui-contract-title", "<gold>Tugas: Kumpulkan {amount} {item}");
+        meta.displayName(mm.deserialize(titleFormat,
+                Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
+                Placeholder.unparsed("item", contract.itemType().name())
+        ));
+
+        // Lore
+        List<Component> lore = new ArrayList<>();
+        String creatorFormat = plugin.getConfig().getString("messages.gui-lore-creator", "<gray>Dibuat oleh: <white>{player}");
+        lore.add(mm.deserialize(creatorFormat, Placeholder.unparsed("player", contract.creatorName())));
+
+        String rewardFormat = plugin.getConfig().getString("messages.gui-lore-reward", "<gray>Imbalan: <green>${reward}");
+        lore.add(mm.deserialize(rewardFormat, Placeholder.unparsed("reward", String.format("%,.2f", contract.reward()))));
+
+        String timeFormat = plugin.getConfig().getString("messages.gui-lore-time", "<gray>Sisa Waktu: <red>{time}");
+        lore.add(mm.deserialize(timeFormat, Placeholder.unparsed("time", TimeParser.formatTime(contract.timeLimit()))));
+
+        lore.add(Component.empty());
+
+        String acceptFormat = plugin.getConfig().getString("messages.gui-lore-accept", "<yellow>Klik untuk menerima kontrak!");
+        lore.add(mm.deserialize(acceptFormat));
+
+        meta.lore(lore);
+        item.setItemMeta(meta);
+
+        return item;
+    }
+}

--- a/src/main/java/com/kartaquest/gui/ContractGUIHolder.java
+++ b/src/main/java/com/kartaquest/gui/ContractGUIHolder.java
@@ -1,0 +1,38 @@
+package com.kartaquest.gui;
+
+import com.kartaquest.data.Contract;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ContractGUIHolder implements InventoryHolder {
+    private final Map<Integer, UUID> slotToContractIdMap = new HashMap<>();
+    private int page;
+
+    public ContractGUIHolder(int page) {
+        this.page = page;
+    }
+
+    public void setContractAtSlot(int slot, UUID contractId) {
+        slotToContractIdMap.put(slot, contractId);
+    }
+
+    public UUID getContractIdAtSlot(int slot) {
+        return slotToContractIdMap.get(slot);
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        // This is required by the interface, but we will create the inventory in the GUI class itself.
+        // We can leave this null as we will be passing the holder instance directly to Bukkit.createInventory.
+        return null;
+    }
+}

--- a/src/main/java/com/kartaquest/listeners/GUIListener.java
+++ b/src/main/java/com/kartaquest/listeners/GUIListener.java
@@ -1,0 +1,64 @@
+package com.kartaquest.listeners;
+
+import com.kartaquest.KartaQuest;
+import com.kartaquest.data.Contract;
+import com.kartaquest.gui.ContractGUIHolder;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.UUID;
+
+public class GUIListener implements Listener {
+
+    private final KartaQuest plugin;
+
+    public GUIListener(KartaQuest plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        Inventory inventory = event.getInventory();
+        if (inventory.getHolder() instanceof ContractGUIHolder holder) {
+            event.setCancelled(true);
+
+            if (!(event.getWhoClicked() instanceof Player player)) return;
+
+            UUID contractId = holder.getContractIdAtSlot(event.getRawSlot());
+            if (contractId == null) {
+                // Handle navigation clicks
+                if (event.getRawSlot() == 45) { // Previous Page
+                    new com.kartaquest.gui.ContractGUI(plugin, player, holder.getPage() - 1).open();
+                } else if (event.getRawSlot() == 53) { // Next Page
+                    new com.kartaquest.gui.ContractGUI(plugin, player, holder.getPage() + 1).open();
+                }
+                return;
+            }
+
+            Contract contract = plugin.getContractManager().getContract(contractId);
+            if (contract == null) return; // Should not happen
+
+            // Prevent creator from accepting their own contract
+            if (player.getUniqueId().equals(contract.creatorUuid())) {
+                player.sendMessage(plugin.getConfigManager().getMessage("cannot-accept-own"));
+                return;
+            }
+
+            if (plugin.getContractManager().hasActiveContract(player.getUniqueId())) {
+                player.sendMessage(plugin.getConfigManager().getMessage("already-has-contract"));
+                return;
+            }
+
+            plugin.getContractManager().acceptContract(contractId, player.getUniqueId());
+            player.closeInventory();
+            player.sendMessage(plugin.getConfigManager().getMessage("contract-accepted",
+                    Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
+                    Placeholder.unparsed("item", contract.itemType().name())
+            ));
+        }
+    }
+}

--- a/src/main/java/com/kartaquest/managers/ConfigManager.java
+++ b/src/main/java/com/kartaquest/managers/ConfigManager.java
@@ -1,0 +1,50 @@
+package com.kartaquest.managers;
+
+import com.kartaquest.KartaQuest;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class ConfigManager {
+
+    private final KartaQuest plugin;
+    private FileConfiguration config;
+    private MiniMessage miniMessage;
+
+    public ConfigManager(KartaQuest plugin) {
+        this.plugin = plugin;
+        this.miniMessage = MiniMessage.miniMessage();
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        plugin.saveDefaultConfig();
+        config = plugin.getConfig();
+        config.options().copyDefaults(true);
+        plugin.saveConfig();
+    }
+
+    public void reloadConfig() {
+        plugin.reloadConfig();
+        config = plugin.getConfig();
+    }
+
+    public Component getMessage(String key, TagResolver... placeholders) {
+        String messageFormat = config.getString("messages." + key, "<red>Missing message for key: " + key + "</red>");
+        String prefix = config.getString("messages.prefix", "");
+
+        return miniMessage.deserialize(prefix + messageFormat, placeholders);
+    }
+
+    public int getMaxContractsPerPlayer() {
+        return config.getInt("max-contracts-per-player", 5);
+    }
+
+    public double getContractCreationTaxPercent() {
+        return config.getDouble("contract-creation-tax-percent", 5.0);
+    }
+}

--- a/src/main/java/com/kartaquest/managers/ContractManager.java
+++ b/src/main/java/com/kartaquest/managers/ContractManager.java
@@ -1,0 +1,208 @@
+package com.kartaquest.managers;
+
+import com.kartaquest.KartaQuest;
+import com.kartaquest.data.Contract;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ContractManager {
+
+    private final KartaQuest plugin;
+    private final Map<UUID, Contract> activeContracts = new ConcurrentHashMap<>();
+
+    public ContractManager(KartaQuest plugin) {
+        this.plugin = plugin;
+        loadContracts();
+    }
+
+    public void loadContracts() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                plugin.getDataManager().reloadContractsConfig();
+                ConfigurationSection contractsSection = plugin.getDataManager().getContractsConfig().getConfigurationSection("contracts");
+                if (contractsSection == null) return;
+
+                for (String key : contractsSection.getKeys(false)) {
+                    UUID contractId = UUID.fromString(key);
+                    String path = "contracts." + key;
+
+                    UUID creatorUuid = UUID.fromString(plugin.getDataManager().getContractsConfig().getString(path + ".creatorUuid"));
+                    String creatorName = plugin.getDataManager().getContractsConfig().getString(path + ".creatorName");
+                    Material itemType = Material.valueOf(plugin.getDataManager().getContractsConfig().getString(path + ".itemType"));
+                    int itemAmount = plugin.getDataManager().getContractsConfig().getInt(path + ".itemAmount");
+                    double reward = plugin.getDataManager().getContractsConfig().getDouble(path + ".reward");
+                    Contract.ContractStatus status = Contract.ContractStatus.valueOf(plugin.getDataManager().getContractsConfig().getString(path + ".status"));
+                    String assigneeUuidString = plugin.getDataManager().getContractsConfig().getString(path + ".assigneeUuid");
+                    UUID assigneeUuid = assigneeUuidString == null || assigneeUuidString.equals("null") ? null : UUID.fromString(assigneeUuidString);
+                    long creationTimestamp = plugin.getDataManager().getContractsConfig().getLong(path + ".creationTimestamp");
+                    long timeLimit = plugin.getDataManager().getContractsConfig().getLong(path + ".timeLimit");
+
+                    Contract contract = new Contract(contractId, creatorUuid, creatorName, itemType, itemAmount, reward, status, assigneeUuid, creationTimestamp, timeLimit);
+                    activeContracts.put(contractId, contract);
+                }
+                plugin.getLogger().info("Loaded " + activeContracts.size() + " contracts.");
+            }
+        }.runTaskAsynchronously(plugin);
+    }
+
+    public void saveContracts() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                plugin.getDataManager().getContractsConfig().set("contracts", null); // Clear old data
+                for (Map.Entry<UUID, Contract> entry : activeContracts.entrySet()) {
+                    String path = "contracts." + entry.getKey().toString();
+                    Contract contract = entry.getValue();
+                    plugin.getDataManager().getContractsConfig().set(path + ".creatorUuid", contract.creatorUuid().toString());
+                    plugin.getDataManager().getContractsConfig().set(path + ".creatorName", contract.creatorName());
+                    plugin.getDataManager().getContractsConfig().set(path + ".itemType", contract.itemType().name());
+                    plugin.getDataManager().getContractsConfig().set(path + ".itemAmount", contract.itemAmount());
+                    plugin.getDataManager().getContractsConfig().set(path + ".reward", contract.reward());
+                    plugin.getDataManager().getContractsConfig().set(path + ".status", contract.status().name());
+                    plugin.getDataManager().getContractsConfig().set(path + ".assigneeUuid", contract.assigneeUuid() != null ? contract.assigneeUuid().toString() : null);
+                    plugin.getDataManager().getContractsConfig().set(path + ".creationTimestamp", contract.creationTimestamp());
+                    plugin.getDataManager().getContractsConfig().set(path + ".timeLimit", contract.timeLimit());
+                }
+                plugin.getDataManager().saveContractsConfig();
+                plugin.getLogger().info("Saved " + activeContracts.size() + " contracts.");
+            }
+        }.runTaskAsynchronously(plugin);
+    }
+
+    public void createContract(UUID creatorUuid, String creatorName, Material itemType, int itemAmount, double reward, long timeLimit) {
+        UUID contractId = UUID.randomUUID();
+        Contract contract = new Contract(
+                contractId,
+                creatorUuid,
+                creatorName,
+                itemType,
+                itemAmount,
+                reward,
+                Contract.ContractStatus.AVAILABLE,
+                null,
+                System.currentTimeMillis(),
+                timeLimit
+        );
+        activeContracts.put(contractId, contract);
+    }
+
+    public Map<UUID, Contract> getActiveContracts() {
+        return activeContracts;
+    }
+
+    public List<Contract> getAvailableContracts() {
+        return activeContracts.values().stream()
+                .filter(c -> c.status() == Contract.ContractStatus.AVAILABLE)
+                .toList();
+    }
+
+    public Contract getContract(UUID contractId) {
+        return activeContracts.get(contractId);
+    }
+
+    public boolean hasActiveContract(UUID playerUuid) {
+        return activeContracts.values().stream()
+                .anyMatch(c -> c.assigneeUuid() != null && c.assigneeUuid().equals(playerUuid));
+    }
+
+    public void acceptContract(UUID contractId, UUID playerUuid) {
+        Contract oldContract = activeContracts.get(contractId);
+        if (oldContract == null || oldContract.status() != Contract.ContractStatus.AVAILABLE) {
+            return; // Or throw an exception
+        }
+        Contract newContract = new Contract(
+                oldContract.contractId(),
+                oldContract.creatorUuid(),
+                oldContract.creatorName(),
+                oldContract.itemType(),
+                oldContract.itemAmount(),
+                oldContract.reward(),
+                Contract.ContractStatus.IN_PROGRESS,
+                playerUuid,
+                oldContract.creationTimestamp(),
+                oldContract.timeLimit()
+        );
+        activeContracts.put(contractId, newContract);
+    }
+
+    public Contract getContractByAssignee(UUID playerUuid) {
+        return activeContracts.values().stream()
+                .filter(c -> c.status() == Contract.ContractStatus.IN_PROGRESS && playerUuid.equals(c.assigneeUuid()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void completeContract(UUID contractId) {
+        Contract oldContract = activeContracts.get(contractId);
+        if (oldContract == null) return;
+
+        Contract newContract = new Contract(
+                oldContract.contractId(),
+                oldContract.creatorUuid(),
+                oldContract.creatorName(),
+                oldContract.itemType(),
+                oldContract.itemAmount(),
+                oldContract.reward(),
+                Contract.ContractStatus.COMPLETED_UNCLAIMED,
+                oldContract.assigneeUuid(),
+                oldContract.creationTimestamp(),
+                oldContract.timeLimit()
+        );
+        activeContracts.put(contractId, newContract);
+    }
+
+    public void cancelContract(UUID contractId) {
+        Contract oldContract = activeContracts.get(contractId);
+        if (oldContract == null) return;
+
+        Contract newContract = new Contract(
+                oldContract.contractId(),
+                oldContract.creatorUuid(),
+                oldContract.creatorName(),
+                oldContract.itemType(),
+                oldContract.itemAmount(),
+                oldContract.reward(),
+                Contract.ContractStatus.AVAILABLE,
+                null, // Remove assignee
+                oldContract.creationTimestamp(),
+                oldContract.timeLimit()
+        );
+        activeContracts.put(contractId, newContract);
+    }
+
+    public List<Contract> getClaimableContracts(UUID creatorUuid) {
+        return activeContracts.values().stream()
+                .filter(c -> c.status() == Contract.ContractStatus.COMPLETED_UNCLAIMED && creatorUuid.equals(c.creatorUuid()))
+                .toList();
+    }
+
+    public void removeContract(UUID contractId) {
+        activeContracts.remove(contractId);
+    }
+
+    public void expireContract(UUID contractId) {
+        Contract oldContract = activeContracts.get(contractId);
+        if (oldContract == null) return;
+
+        Contract newContract = new Contract(
+                oldContract.contractId(),
+                oldContract.creatorUuid(),
+                oldContract.creatorName(),
+                oldContract.itemType(),
+                oldContract.itemAmount(),
+                oldContract.reward(),
+                Contract.ContractStatus.EXPIRED,
+                oldContract.assigneeUuid(),
+                oldContract.creationTimestamp(),
+                oldContract.timeLimit()
+        );
+        activeContracts.put(contractId, newContract);
+    }
+}

--- a/src/main/java/com/kartaquest/managers/EconomyManager.java
+++ b/src/main/java/com/kartaquest/managers/EconomyManager.java
@@ -1,0 +1,57 @@
+package com.kartaquest.managers;
+
+import com.kartaquest.KartaQuest;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class EconomyManager {
+
+    private final KartaQuest plugin;
+    private Economy economy;
+
+    public EconomyManager(KartaQuest plugin) {
+        this.plugin = plugin;
+        setupEconomy();
+    }
+
+    private void setupEconomy() {
+        if (plugin.getServer().getPluginManager().getPlugin("Vault") == null) {
+            plugin.getLogger().severe("Vault not found! Disabling KartaQuest.");
+            plugin.getServer().getPluginManager().disablePlugin(plugin);
+            return;
+        }
+        RegisteredServiceProvider<Economy> rsp = plugin.getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            plugin.getLogger().severe("No economy provider found! Disabling KartaQuest.");
+            plugin.getServer().getPluginManager().disablePlugin(plugin);
+            return;
+        }
+        economy = rsp.getProvider();
+    }
+
+    public boolean hasAccount(OfflinePlayer player) {
+        return economy.hasAccount(player);
+    }
+
+    public double getBalance(OfflinePlayer player) {
+        return economy.getBalance(player);
+    }
+
+    public boolean has(OfflinePlayer player, double amount) {
+        return economy.has(player, amount);
+    }
+
+    public EconomyResponse withdrawPlayer(OfflinePlayer player, double amount) {
+        return economy.withdrawPlayer(player, amount);
+    }
+
+    public EconomyResponse depositPlayer(OfflinePlayer player, double amount) {
+        return economy.depositPlayer(player, amount);
+    }
+
+    public Economy getEconomy() {
+        return economy;
+    }
+}

--- a/src/main/java/com/kartaquest/managers/ReputationManager.java
+++ b/src/main/java/com/kartaquest/managers/ReputationManager.java
@@ -1,0 +1,93 @@
+package com.kartaquest.managers;
+
+import com.kartaquest.KartaQuest;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ReputationManager {
+
+    private final KartaQuest plugin;
+    private final Map<UUID, Integer> reputationCache = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> completedContractsCache = new ConcurrentHashMap<>();
+
+    public ReputationManager(KartaQuest plugin) {
+        this.plugin = plugin;
+        loadReputations(); // This will be expanded to load completed counts too
+    }
+
+    public void loadReputations() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                plugin.getDataManager().reloadReputationsConfig();
+
+                // Load reputations
+                ConfigurationSection repSection = plugin.getDataManager().getReputationsConfig().getConfigurationSection("reputations");
+                if (repSection != null) {
+                    for (String key : repSection.getKeys(false)) {
+                        UUID playerUuid = UUID.fromString(key);
+                        int reputation = plugin.getDataManager().getReputationsConfig().getInt("reputations." + key);
+                        reputationCache.put(playerUuid, reputation);
+                    }
+                }
+
+                // Load completed counts
+                ConfigurationSection completedSection = plugin.getDataManager().getReputationsConfig().getConfigurationSection("completed-contracts");
+                if (completedSection != null) {
+                    for (String key : completedSection.getKeys(false)) {
+                        UUID playerUuid = UUID.fromString(key);
+                        int count = plugin.getDataManager().getReputationsConfig().getInt("completed-contracts." + key);
+                        completedContractsCache.put(playerUuid, count);
+                    }
+                }
+                plugin.getLogger().info("Loaded " + reputationCache.size() + " reputation entries and " + completedContractsCache.size() + " completion records.");
+            }
+        }.runTaskAsynchronously(plugin);
+    }
+
+    public void saveReputations() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                // Save reputations
+                plugin.getDataManager().getReputationsConfig().set("reputations", null);
+                for (Map.Entry<UUID, Integer> entry : reputationCache.entrySet()) {
+                    plugin.getDataManager().getReputationsConfig().set("reputations." + entry.getKey().toString(), entry.getValue());
+                }
+
+                // Save completed counts
+                plugin.getDataManager().getReputationsConfig().set("completed-contracts", null);
+                for (Map.Entry<UUID, Integer> entry : completedContractsCache.entrySet()) {
+                    plugin.getDataManager().getReputationsConfig().set("completed-contracts." + entry.getKey().toString(), entry.getValue());
+                }
+
+                plugin.getDataManager().saveReputationsConfig();
+                plugin.getLogger().info("Saved " + reputationCache.size() + " reputation entries and " + completedContractsCache.size() + " completion records.");
+            }
+        }.runTaskAsynchronously(plugin);
+    }
+
+    public int getReputation(UUID playerUuid) {
+        return reputationCache.getOrDefault(playerUuid, 0);
+    }
+
+    public void addReputation(UUID playerUuid, int amount) {
+        reputationCache.put(playerUuid, getReputation(playerUuid) + amount);
+    }
+
+    public void removeReputation(UUID playerUuid, int amount) {
+        reputationCache.put(playerUuid, getReputation(playerUuid) - amount);
+    }
+
+    public int getCompletedContracts(UUID playerUuid) {
+        return completedContractsCache.getOrDefault(playerUuid, 0);
+    }
+
+    public void incrementCompletedContracts(UUID playerUuid) {
+        completedContractsCache.put(playerUuid, getCompletedContracts(playerUuid) + 1);
+    }
+}

--- a/src/main/java/com/kartaquest/utils/DataManager.java
+++ b/src/main/java/com/kartaquest/utils/DataManager.java
@@ -1,0 +1,80 @@
+package com.kartaquest.utils;
+
+import com.kartaquest.KartaQuest;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DataManager {
+
+    private final KartaQuest plugin;
+    private FileConfiguration contractsConfig;
+    private File contractsFile;
+    private FileConfiguration reputationsConfig;
+    private File reputationsFile;
+
+    public DataManager(KartaQuest plugin) {
+        this.plugin = plugin;
+        setup();
+    }
+
+    public void setup() {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdir();
+        }
+
+        contractsFile = new File(plugin.getDataFolder(), "contracts.yml");
+        if (!contractsFile.exists()) {
+            try {
+                contractsFile.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().severe("Could not create contracts.yml!");
+            }
+        }
+        contractsConfig = YamlConfiguration.loadConfiguration(contractsFile);
+
+        reputationsFile = new File(plugin.getDataFolder(), "reputations.yml");
+        if (!reputationsFile.exists()) {
+            try {
+                reputationsFile.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().severe("Could not create reputations.yml!");
+            }
+        }
+        reputationsConfig = YamlConfiguration.loadConfiguration(reputationsFile);
+    }
+
+    public FileConfiguration getContractsConfig() {
+        return contractsConfig;
+    }
+
+    public void saveContractsConfig() {
+        try {
+            contractsConfig.save(contractsFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save to contracts.yml!");
+        }
+    }
+
+    public void reloadContractsConfig() {
+        contractsConfig = YamlConfiguration.loadConfiguration(contractsFile);
+    }
+
+    public FileConfiguration getReputationsConfig() {
+        return reputationsConfig;
+    }
+
+    public void saveReputationsConfig() {
+        try {
+            reputationsConfig.save(reputationsFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save to reputations.yml!");
+        }
+    }
+
+    public void reloadReputationsConfig() {
+        reputationsConfig = YamlConfiguration.loadConfiguration(reputationsFile);
+    }
+}

--- a/src/main/java/com/kartaquest/utils/TimeParser.java
+++ b/src/main/java/com/kartaquest/utils/TimeParser.java
@@ -1,0 +1,61 @@
+package com.kartaquest.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeParser {
+
+    private static final Pattern TIME_PATTERN = Pattern.compile("(\\d+)([smhd])");
+
+    public static long parseTime(String timeString) {
+        long totalSeconds = 0;
+        Matcher matcher = TIME_PATTERN.matcher(timeString.toLowerCase());
+        while (matcher.find()) {
+            int value = Integer.parseInt(matcher.group(1));
+            String unit = matcher.group(2);
+            switch (unit) {
+                case "s":
+                    totalSeconds += value;
+                    break;
+                case "m":
+                    totalSeconds += TimeUnit.MINUTES.toSeconds(value);
+                    break;
+                case "h":
+                    totalSeconds += TimeUnit.HOURS.toSeconds(value);
+                    break;
+                case "d":
+                    totalSeconds += TimeUnit.DAYS.toSeconds(value);
+                    break;
+            }
+        }
+        return totalSeconds > 0 ? System.currentTimeMillis() + (totalSeconds * 1000) : 0;
+    }
+
+    public static String formatTime(long expiryTimestamp) {
+        if (expiryTimestamp == 0) {
+            return "Never";
+        }
+        long remainingMillis = expiryTimestamp - System.currentTimeMillis();
+        if (remainingMillis <= 0) {
+            return "Expired";
+        }
+
+        long days = TimeUnit.MILLISECONDS.toDays(remainingMillis);
+        remainingMillis -= TimeUnit.DAYS.toMillis(days);
+        long hours = TimeUnit.MILLISECONDS.toHours(remainingMillis);
+        remainingMillis -= TimeUnit.HOURS.toMillis(hours);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(remainingMillis);
+
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) sb.append(days).append("d ");
+        if (hours > 0) sb.append(hours).append("h ");
+        if (minutes > 0) sb.append(minutes).append("m");
+
+        if (sb.length() == 0) {
+            return "<1m";
+        }
+
+        return sb.toString().trim();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,58 @@
+# KartaQuest Configuration File
+#
+# All messages support MiniMessage format.
+# Learn more here: https://docs.advntr.dev/minimessage/format.html
+
+# General settings
+max-contracts-per-player: 5
+contract-creation-tax-percent: 5.0
+
+# Messages
+messages:
+  prefix: "<dark_gray>[<gold>KartaQuest<dark_gray>]<reset> "
+
+  # Command Messages
+  player-only-command: "<red>This command can only be run by a player."
+  unknown-command: "<red>Unknown command. Use <yellow>/kartaquest help</yellow> for assistance."
+
+  # Contract Creation
+  contract-created: "<green>Successfully created a contract to collect <aqua>{amount} {item}</aqua> for <gold>${price}</gold>."
+  creation-usage: "<red>Usage: /kartaquest create <item> <amount> <price>"
+  invalid-item: "<red>Invalid item type: <yellow>{item}</yellow>."
+  invalid-amount: "<red>Amount must be a positive number."
+  invalid-price: "<red>Price must be a positive number."
+  insufficient-funds: "<red>You don't have enough money. You need <gold>${price}</gold> plus a <gold>${tax}</gold> tax."
+  max-contracts-reached: "<red>You have reached the maximum of <aqua>{max}</aqua> active contracts."
+
+  # Contract Interaction
+  contract-accepted: "<green>You have accepted the contract to collect <aqua>{amount} {item}</aqua>."
+  cannot-accept-own: "<red>You cannot accept your own contract."
+  already-has-contract: "<red>You already have an active contract. Use <yellow>/kq status</yellow> to see it."
+  no-active-contract: "<gray>You do not have an active contract."
+  contract-status: "<green>Your current contract:\n <gray>Task: <white>Collect {amount} {item}\n <gray>Reward: <gold>${reward}\n <gray>Creator: <white>{creator}"
+  contract-completed: "<green>Contract completed! You earned <gold>${reward}</gold> and <aqua>+1</aqua> reputation."
+  not-enough-items: "<red>You don't have the required items. You need <aqua>{amount} {item}</aqua>."
+  contract-cancelled: "<yellow>You have cancelled your contract and lost <red>1</red> reputation point."
+
+  # Claiming
+  no-items-to-claim: "<gray>You have no completed contracts to claim items from."
+  claimed-items: "<green>Claimed <aqua>{amount} {item}</aqua> from a completed contract."
+
+  # Reputation
+  reputation-check-self: "<gray>Your current reputation is: <aqua>{reputation}</aqua>."
+  reputation-check-other: "<gray>{player}'s reputation is: <aqua>{reputation}</aqua>."
+  player-not-found: "<red>Player not found."
+
+  # GUI
+  gui-title: "<blue>Quest Board (Page {page}/{total_pages})"
+  gui-contract-title: "<gold>Tugas: Kumpulkan {amount} {item}"
+  gui-lore-creator: "<gray>Dibuat oleh: <white>{player}"
+  gui-lore-reward: "<gray>Imbalan: <green>${reward}"
+  gui-lore-accept: "<yellow>Klik untuk menerima kontrak!"
+  gui-lore-time: "<gray>Sisa Waktu: <red>{time}"
+
+  # Admin
+  config-reloaded: "<green>KartaQuest configuration has been reloaded."
+  contract-deleted: "<green>Contract <aqua>{id}</aqua> has been forcefully deleted."
+  contract-not-found: "<red>Contract with ID <aqua>{id}</aqua> not found."
+  admin-help: "<gray>Admin commands: reload, delete <id>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,17 @@
+name: KartaQuest
+version: '${project.version}'
+main: com.kartaquest.KartaQuest
+api-version: '1.21'
+author: MinekartaStudio
+description: A quest/contract board plugin for PaperMC.
+depend:
+  - Vault
+  - PlaceholderAPI
+
+commands:
+  kartaquest:
+    description: Main command for the KartaQuest plugin.
+    aliases: [quest, quests, kq, kontrak]
+  reputations:
+    description: Check your or another player's reputation.
+    aliases: [rep, reputasi]


### PR DESCRIPTION
This commit introduces the KartaQuest plugin, a comprehensive contract and quest board system for PaperMC servers.

Features:
- **Contract Lifecycle**: Players can create, accept, complete, cancel, and claim contracts.
- **GUI-based Quest Board**: An interactive GUI with pagination allows players to browse and accept available quests.
- **Economy Integration**: Utilizes Vault for all economic transactions, including an escrow system for contract rewards and a configurable creation tax.
- **Reputation System**: Players gain and lose reputation for completing or canceling contracts.
- **PlaceholderAPI Support**: Exposes various stats like reputation and completed contracts through a PAPI expansion.
- **Configurability**: Almost all messages and settings are configurable via `config.yml` using MiniMessage format.
- **Data Persistence**: All contract and reputation data is saved asynchronously to YML files to prevent server lag.
- **Admin Commands**: Includes commands for reloading the configuration and deleting contracts.