### PR TITLE
Fix IllegalPluginAccessException on disable

### DIFF
--- a/src/main/java/com/kartaquest/KartaQuest.java
+++ b/src/main/java/com/kartaquest/KartaQuest.java
@@ -68,7 +68,7 @@ public final class KartaQuest extends JavaPlugin {
     public void onDisable() {
         // Save data on disable
         if (contractManager != null) {
-            contractManager.saveContracts();
+            contractManager.saveContractsSync();
         }
         if (reputationManager != null) {
             reputationManager.saveReputations();

--- a/src/main/java/com/kartaquest/managers/ContractManager.java
+++ b/src/main/java/com/kartaquest/managers/ContractManager.java
@@ -76,6 +76,25 @@ public class ContractManager {
         }.runTaskAsynchronously(plugin);
     }
 
+    public void saveContractsSync() {
+        plugin.getDataManager().getContractsConfig().set("contracts", null); // Clear old data
+        for (Map.Entry<UUID, Contract> entry : activeContracts.entrySet()) {
+            String path = "contracts." + entry.getKey().toString();
+            Contract contract = entry.getValue();
+            plugin.getDataManager().getContractsConfig().set(path + ".creatorUuid", contract.creatorUuid().toString());
+            plugin.getDataManager().getContractsConfig().set(path + ".creatorName", contract.creatorName());
+            plugin.getDataManager().getContractsConfig().set(path + ".itemType", contract.itemType().name());
+            plugin.getDataManager().getContractsConfig().set(path + ".itemAmount", contract.itemAmount());
+            plugin.getDataManager().getContractsConfig().set(path + ".reward", contract.reward());
+            plugin.getDataManager().getContractsConfig().set(path + ".status", contract.status().name());
+            plugin.getDataManager().getContractsConfig().set(path + ".assigneeUuid", contract.assigneeUuid() != null ? contract.assigneeUuid().toString() : null);
+            plugin.getDataManager().getContractsConfig().set(path + ".creationTimestamp", contract.creationTimestamp());
+            plugin.getDataManager().getContractsConfig().set(path + ".timeLimit", contract.timeLimit());
+        }
+        plugin.getDataManager().saveContractsConfig();
+        plugin.getLogger().info("Saved " + activeContracts.size() + " contracts.");
+    }
+
     public void createContract(UUID creatorUuid, String creatorName, Material itemType, int itemAmount, double reward, long timeLimit) {
         UUID contractId = UUID.randomUUID();
         Contract contract = new Contract(


### PR DESCRIPTION
The `saveContracts` method was scheduling an asynchronous task to save contract data. This is not allowed when the plugin is being disabled, as all operations must be synchronous during shutdown.

This commit introduces a new synchronous method `saveContractsSync` in `ContractManager` and calls it from `KartaQuest.onDisable`. This ensures that contract data is saved correctly without causing an `IllegalPluginAccessException`.