### PR TITLE
Fix IllegalPluginAccessException for ReputationManager

### DIFF
--- a/src/main/java/com/kartaquest/KartaQuest.java
+++ b/src/main/java/com/kartaquest/KartaQuest.java
@@ -68,10 +68,10 @@ public final class KartaQuest extends JavaPlugin {
     public void onDisable() {
         // Save data on disable
         if (contractManager != null) {
-            contractManager.saveContracts();
+            contractManager.saveContractsSync();
         }
         if (reputationManager != null) {
-            reputationManager.saveReputations();
+            reputationManager.saveReputationsSync();
         }
         getLogger().info("KartaQuest has been disabled!");
     }

--- a/src/main/java/com/kartaquest/managers/ContractManager.java
+++ b/src/main/java/com/kartaquest/managers/ContractManager.java
@@ -76,6 +76,25 @@ public class ContractManager {
         }.runTaskAsynchronously(plugin);
     }
 
+    public void saveContractsSync() {
+        plugin.getDataManager().getContractsConfig().set("contracts", null); // Clear old data
+        for (Map.Entry<UUID, Contract> entry : activeContracts.entrySet()) {
+            String path = "contracts." + entry.getKey().toString();
+            Contract contract = entry.getValue();
+            plugin.getDataManager().getContractsConfig().set(path + ".creatorUuid", contract.creatorUuid().toString());
+            plugin.getDataManager().getContractsConfig().set(path + ".creatorName", contract.creatorName());
+            plugin.getDataManager().getContractsConfig().set(path + ".itemType", contract.itemType().name());
+            plugin.getDataManager().getContractsConfig().set(path + ".itemAmount", contract.itemAmount());
+            plugin.getDataManager().getContractsConfig().set(path + ".reward", contract.reward());
+            plugin.getDataManager().getContractsConfig().set(path + ".status", contract.status().name());
+            plugin.getDataManager().getContractsConfig().set(path + ".assigneeUuid", contract.assigneeUuid() != null ? contract.assigneeUuid().toString() : null);
+            plugin.getDataManager().getContractsConfig().set(path + ".creationTimestamp", contract.creationTimestamp());
+            plugin.getDataManager().getContractsConfig().set(path + ".timeLimit", contract.timeLimit());
+        }
+        plugin.getDataManager().saveContractsConfig();
+        plugin.getLogger().info("Saved " + activeContracts.size() + " contracts.");
+    }
+
     public void createContract(UUID creatorUuid, String creatorName, Material itemType, int itemAmount, double reward, long timeLimit) {
         UUID contractId = UUID.randomUUID();
         Contract contract = new Contract(

--- a/src/main/java/com/kartaquest/managers/ReputationManager.java
+++ b/src/main/java/com/kartaquest/managers/ReputationManager.java
@@ -71,6 +71,23 @@ public class ReputationManager {
         }.runTaskAsynchronously(plugin);
     }
 
+    public void saveReputationsSync() {
+        // Save reputations
+        plugin.getDataManager().getReputationsConfig().set("reputations", null);
+        for (Map.Entry<UUID, Integer> entry : reputationCache.entrySet()) {
+            plugin.getDataManager().getReputationsConfig().set("reputations." + entry.getKey().toString(), entry.getValue());
+        }
+
+        // Save completed counts
+        plugin.getDataManager().getReputationsConfig().set("completed-contracts", null);
+        for (Map.Entry<UUID, Integer> entry : completedContractsCache.entrySet()) {
+            plugin.getDataManager().getReputationsConfig().set("completed-contracts." + entry.getKey().toString(), entry.getValue());
+        }
+
+        plugin.getDataManager().saveReputationsConfig();
+        plugin.getLogger().info("Saved " + reputationCache.size() + " reputation entries and " + completedContractsCache.size() + " completion records.");
+    }
+
     public int getReputation(UUID playerUuid) {
         return reputationCache.getOrDefault(playerUuid, 0);
     }


### PR DESCRIPTION
This follows up on the previous commit to fix another instance of an `IllegalPluginAccessException` that occurs when the plugin is disabled. The `ReputationManager.saveReputations` method was also scheduling an asynchronous task, which is not allowed during shutdown.

This commit introduces a `saveReputationsSync` method and calls it from `onDisable` to ensure data is saved synchronously.