### PR TITLE
The plugin name 'Player Contract' in plugin.yml contains a space, whi…

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: Player Contract
+name: PlayerContract
 version: '${project.version}'
 main: com.playercontract.PlayerContract
 api-version: '1.21'


### PR DESCRIPTION
…ch is a restricted character that causes an `InvalidDescriptionException` on Paper servers. This commit removes the space, changing the name to 'PlayerContract' to ensure the plugin can be loaded correctly.