### PR TITLE
Refactor the Player Inventory GUI (`/pc inv`) to display contracts cr…

### DIFF
--- a/src/main/java/com/playercontract/gui/PlayerInventoryGUI.java
+++ b/src/main/java/com/playercontract/gui/PlayerInventoryGUI.java
@@ -4,9 +4,11 @@ import com.playercontract.PlayerContract;
 import com.playercontract.data.Contract;
 import com.playercontract.utils.TimeParser;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -14,7 +16,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class PlayerInventoryGUI {
 
@@ -28,83 +29,79 @@ public class PlayerInventoryGUI {
 
     public void open() {
         PlayerInventoryGUIHolder holder = new PlayerInventoryGUIHolder();
-        Component title = plugin.getConfigManager().getMessage("inventory-gui-title", player, false);
+        // Using a hardcoded title for now, can be moved to config later
+        Component title = Component.text("Your Created Contracts");
         Inventory gui = Bukkit.createInventory(holder, 54, title);
 
-        List<Contract> inProgressContracts = plugin.getContractManager().getInProgressContracts(player.getUniqueId());
-        List<Contract> completedContracts = plugin.getContractManager().getCompletedContracts(player.getUniqueId());
+        List<Contract> createdContracts = plugin.getContractManager().getContractsByCreator(player.getUniqueId());
 
-        // Populate In-Progress Contracts
-        for (int i = 0; i < inProgressContracts.size(); i++) {
-            if (i >= 27) break; // Max 3 rows for in-progress
-            Contract contract = inProgressContracts.get(i);
-            gui.setItem(i, createInProgressItem(contract));
+        for (int i = 0; i < createdContracts.size(); i++) {
+            if (i >= 54) break; // Max inventory size
+            Contract contract = createdContracts.get(i);
+            gui.setItem(i, createCreatedContractItem(contract));
             holder.setContractAtSlot(i, contract.contractId());
-        }
-
-        // Populate Completed Contracts
-        // Starting from slot 36 to leave a gap
-        for (int i = 0; i < completedContracts.size(); i++) {
-            int slot = 36 + i;
-            if (slot >= 54) break; // Max 2 rows for completed
-            Contract contract = completedContracts.get(i);
-            gui.setItem(slot, createCompletedItem(contract));
-            holder.setContractAtSlot(slot, contract.contractId());
-        }
-
-        // Add a separator
-        ItemStack separator = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
-        ItemMeta meta = separator.getItemMeta();
-        meta.displayName(Component.text(" "));
-        separator.setItemMeta(meta);
-        for (int i = 27; i < 36; i++) {
-            gui.setItem(i, separator);
         }
 
         player.openInventory(gui);
     }
 
-    private ItemStack createInProgressItem(Contract contract) {
-        ItemStack item = new ItemStack(Material.WRITABLE_BOOK);
-        ItemMeta meta = item.getItemMeta();
-
-        meta.displayName(plugin.getConfigManager().getMessage("inventory-gui-in-progress-item-name", player, false,
-                Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
-                Placeholder.unparsed("item", contract.itemType().name())
-        ));
-
-        List<String> loreLines = plugin.getConfig().getStringList("messages.inventory-gui-in-progress-item-lore");
+    private ItemStack createCreatedContractItem(Contract contract) {
+        ItemStack item;
+        ItemMeta meta;
         List<Component> lore = new ArrayList<>();
-        for (String line : loreLines) {
-            lore.add(plugin.getConfigManager().parse(line, player,
-                    Placeholder.unparsed("reward", String.format("%,.2f", contract.reward())),
-                    Placeholder.unparsed("creator", contract.creatorName()),
-                    Placeholder.unparsed("time_accepted", TimeParser.formatTimeElapsed(contract.acceptedTimestamp()))
-            ));
-        }
 
-        meta.lore(lore);
-        item.setItemMeta(meta);
-        return item;
-    }
+        // Common lore parts
+        lore.add(Component.text(""));
+        lore.add(Component.text("Item: ").color(NamedTextColor.GRAY)
+                .append(Component.text(contract.itemAmount() + "x " + contract.itemType().name()).color(NamedTextColor.WHITE)));
+        lore.add(Component.text("Reward: ").color(NamedTextColor.GRAY)
+                .append(Component.text(String.format("%,.2f", contract.reward())).color(NamedTextColor.GOLD)));
 
-    private ItemStack createCompletedItem(Contract contract) {
-        ItemStack item = new ItemStack(Material.ENCHANTED_BOOK);
-        ItemMeta meta = item.getItemMeta();
 
-        meta.displayName(plugin.getConfigManager().getMessage("inventory-gui-completed-item-name", player, false,
-                Placeholder.unparsed("amount", String.valueOf(contract.itemAmount())),
-                Placeholder.unparsed("item", contract.itemType().name())
-        ));
+        switch (contract.status()) {
+            case AVAILABLE:
+                item = new ItemStack(Material.BOOK);
+                meta = item.getItemMeta();
+                meta.displayName(Component.text("Status: AVAILABLE").color(NamedTextColor.GREEN));
+                lore.add(Component.text("This contract is waiting for someone to accept it.").color(NamedTextColor.GRAY));
+                break;
 
-        List<String> loreLines = plugin.getConfig().getStringList("messages.inventory-gui-completed-item-lore");
-        List<Component> lore = new ArrayList<>();
-        for (String line : loreLines) {
-            lore.add(plugin.getConfigManager().parse(line, player,
-                    Placeholder.unparsed("reward", String.format("%,.2f", contract.reward())),
-                    Placeholder.unparsed("creator", contract.creatorName()),
-                    Placeholder.unparsed("time_completed", TimeParser.formatTimeElapsed(contract.completedTimestamp()))
-            ));
+            case IN_PROGRESS:
+                item = new ItemStack(Material.WRITABLE_BOOK);
+                meta = item.getItemMeta();
+                meta.displayName(Component.text("Status: IN PROGRESS").color(NamedTextColor.YELLOW));
+                OfflinePlayer assignee = Bukkit.getOfflinePlayer(contract.assigneeUuid());
+                lore.add(Component.text("Accepted by: ").color(NamedTextColor.GRAY)
+                        .append(Component.text(assignee.getName() != null ? assignee.getName() : "Unknown").color(NamedTextColor.WHITE)));
+                lore.add(Component.text("Accepted: ").color(NamedTextColor.GRAY)
+                        .append(Component.text(TimeParser.formatTimeElapsed(contract.acceptedTimestamp()) + " ago").color(NamedTextColor.WHITE)));
+                break;
+
+            case COMPLETED_UNCLAIMED:
+                item = new ItemStack(Material.ENCHANTED_BOOK);
+                meta = item.getItemMeta();
+                meta.displayName(Component.text("Status: COMPLETED").color(NamedTextColor.AQUA));
+                OfflinePlayer completer = Bukkit.getOfflinePlayer(contract.assigneeUuid());
+                lore.add(Component.text("Completed by: ").color(NamedTextColor.GRAY)
+                        .append(Component.text(completer.getName() != null ? completer.getName() : "Unknown").color(NamedTextColor.WHITE)));
+                lore.add(Component.text("Completed: ").color(NamedTextColor.GRAY)
+                        .append(Component.text(TimeParser.formatTimeElapsed(contract.completedTimestamp()) + " ago").color(NamedTextColor.WHITE)));
+                lore.add(Component.text(""));
+                lore.add(Component.text("You can claim the items with /pc claim.").color(NamedTextColor.GOLD));
+                break;
+
+            case EXPIRED:
+                item = new ItemStack(Material.BARRIER);
+                meta = item.getItemMeta();
+                meta.displayName(Component.text("Status: EXPIRED").color(NamedTextColor.RED));
+                lore.add(Component.text("This contract expired and was not completed.").color(NamedTextColor.GRAY));
+                break;
+
+            default:
+                item = new ItemStack(Material.STONE);
+                meta = item.getItemMeta();
+                meta.displayName(Component.text("Status: UNKNOWN").color(NamedTextColor.DARK_GRAY));
+                break;
         }
 
         meta.lore(lore);

--- a/src/main/java/com/playercontract/managers/ContractManager.java
+++ b/src/main/java/com/playercontract/managers/ContractManager.java
@@ -252,4 +252,10 @@ public class ContractManager {
                 .filter(c -> c.status() == Contract.ContractStatus.COMPLETED_UNCLAIMED && playerUuid.equals(c.assigneeUuid()))
                 .toList();
     }
+
+    public List<Contract> getContractsByCreator(UUID creatorUuid) {
+        return activeContracts.values().stream()
+                .filter(c -> c.creatorUuid().equals(creatorUuid))
+                .toList();
+    }
 }


### PR DESCRIPTION
…eated by the player, rather than contracts they have accepted.

The previous implementation showed a player's "in-progress" and "completed" accepted contracts, which was not what users expected. Users wanted to see the status of the contracts they had created and posted for others.

This change introduces:
- A new `getContractsByCreator` method in `ContractManager` to fetch all contracts created by a UUID.
- A complete overhaul of `PlayerInventoryGUI` to use this new method.
- A new item generation method that displays each created contract with a unique icon and lore based on its status (Available, In Progress, Completed, Expired), providing a clear and useful overview for the player.